### PR TITLE
Fix reference event dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ detail: { tableName: 'sys_user' }
 
 Listen for this event in UI Builder and provide the resulting fields back to the
 component via the `referenceFields` property to update the modal with the dot
-walked table's fields. Both the property and the `reference-table-requested`
-event are declared in `now-ui.json` so they appear in the UI Builder
-configuration panel.
+walked table's fields. The property and the `reference-table-requested` event are
+declared in `now-ui.json` as an action and output event so they appear in the UI
+Builder configuration panel.

--- a/now-ui.json
+++ b/now-ui.json
@@ -47,6 +47,22 @@
           "itemType": "object"
         }
       ],
+      "actions": [
+        {
+          "name": "reference-table-requested",
+          "label": "Reference Table Requested",
+          "description": "Request to load fields for a referenced table",
+          "action": "reference-table-requested",
+          "payload": [
+            {
+              "name": "tableName",
+              "label": "Table Name",
+              "description": "Name of the referenced table to fetch fields from",
+              "type": "string"
+            }
+          ]
+        }
+      ],
       "events": [
         {
           "name": "reference-table-requested",

--- a/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
@@ -1,4 +1,4 @@
-export const addFieldPickersToDesigner = (designer, tableFields) => {
+export const addFieldPickersToDesigner = (designer, tableFields, dispatch) => {
     console.log("addFieldPickersToDesigner called with:", {
         designer: designer,
         tableFieldsCount: tableFields?.length || 0,
@@ -100,6 +100,9 @@ export const addFieldPickersToDesigner = (designer, tableFields) => {
                             detail: { tableName: field.referenceTable }
                         });
                         designer.hostElement.dispatchEvent(event);
+                        if (typeof dispatch === "function") {
+                            dispatch({ type: "reference-table-requested", payload: { tableName: field.referenceTable } });
+                        }
                     };
                     item.appendChild(arrow);
                 }

--- a/src/x-apig-adaptive-cards-designer-servicenow/index.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/index.js
@@ -101,7 +101,7 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
 
 					// Add field pickers to the designer right away since we have the instance
 					if (designer) {
-						addFieldPickersToDesigner(designer, parsedFields);
+                                                addFieldPickersToDesigner(designer, parsedFields, dispatch);
 					} else {
 						console.warn("Designer not properly initialized, field pickers couldn't be added");
 					}
@@ -118,7 +118,7 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                                         updateState({ tableFields: parsedFields });
 
                                         if (designer) {
-                                                addFieldPickersToDesigner(designer, parsedFields);
+                                                addFieldPickersToDesigner(designer, parsedFields, dispatch);
                                         }
                                 }
 			} catch (error) {
@@ -156,7 +156,7 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
 				
 				// Add field pickers if designer is initialized
                                 if (state.designer) {
-                                        addFieldPickersToDesigner(state.designer, parsedFields);
+                                        addFieldPickersToDesigner(state.designer, parsedFields, dispatch);
                                 } else {
                                         console.warn("Designer not initialized yet, field pickers will be added when it's ready");
                                 }
@@ -168,7 +168,7 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                                 updateState({ tableFields: parsedFields });
 
                                 if (state.designer) {
-                                        addFieldPickersToDesigner(state.designer, parsedFields);
+                                        addFieldPickersToDesigner(state.designer, parsedFields, dispatch);
                                 } else {
                                         console.warn("Designer not initialized yet, field pickers will be added when it's ready");
                                 }


### PR DESCRIPTION
## Summary
- document reference field event in README
- define `reference-table-requested` action in now-ui.json
- dispatch action object when dot walking reference fields

## Testing
- `npm test` *(fails: Missing script)*