### PR TITLE
Fix reference event action dispatch

### DIFF
--- a/now-ui.json
+++ b/now-ui.json
@@ -61,6 +61,21 @@
           }
         }
       ],
+      "actions": [
+        {
+          "name": "reference-table-requested",
+          "description": "Dispatched when requesting fields from a referenced table",
+          "action": "reference-table-requested",
+          "payload": [
+            {
+              "name": "tableName",
+              "label": "Table Name",
+              "description": "Name of the referenced table",
+              "type": "string"
+            }
+          ]
+        }
+      ],
       "uiBuilder": {
         "associatedTypes": [
           "global.core",

--- a/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
@@ -1,4 +1,4 @@
-export const addFieldPickersToDesigner = (designer, tableFields) => {
+export const addFieldPickersToDesigner = (designer, tableFields, dispatch) => {
     console.log("addFieldPickersToDesigner called with:", {
         designer: designer,
         tableFieldsCount: tableFields?.length || 0,
@@ -100,6 +100,12 @@ export const addFieldPickersToDesigner = (designer, tableFields) => {
                             detail: { tableName: field.referenceTable }
                         });
                         designer.hostElement.dispatchEvent(event);
+                        if (typeof dispatch === "function") {
+                            dispatch({
+                                type: "reference-table-requested",
+                                payload: { tableName: field.referenceTable }
+                            });
+                        }
                     };
                     item.appendChild(arrow);
                 }

--- a/src/x-apig-adaptive-cards-designer-servicenow/index.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/index.js
@@ -101,7 +101,7 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
 
 					// Add field pickers to the designer right away since we have the instance
 					if (designer) {
-						addFieldPickersToDesigner(designer, parsedFields);
+                                                addFieldPickersToDesigner(designer, parsedFields, dispatch);
 					} else {
 						console.warn("Designer not properly initialized, field pickers couldn't be added");
 					}
@@ -118,7 +118,7 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                                         updateState({ tableFields: parsedFields });
 
                                         if (designer) {
-                                                addFieldPickersToDesigner(designer, parsedFields);
+                                                addFieldPickersToDesigner(designer, parsedFields, dispatch);
                                         }
                                 }
 			} catch (error) {
@@ -156,7 +156,7 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
 				
 				// Add field pickers if designer is initialized
                                 if (state.designer) {
-                                        addFieldPickersToDesigner(state.designer, parsedFields);
+                                        addFieldPickersToDesigner(state.designer, parsedFields, dispatch);
                                 } else {
                                         console.warn("Designer not initialized yet, field pickers will be added when it's ready");
                                 }
@@ -168,7 +168,7 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                                 updateState({ tableFields: parsedFields });
 
                                 if (state.designer) {
-                                        addFieldPickersToDesigner(state.designer, parsedFields);
+                                        addFieldPickersToDesigner(state.designer, parsedFields, dispatch);
                                 } else {
                                         console.warn("Designer not initialized yet, field pickers will be added when it's ready");
                                 }


### PR DESCRIPTION
## Summary
- dispatch `reference-table-requested` via framework as `{type, payload}`
- list the event under `actions` in `now-ui.json` so UI Builder can configure it

## Testing
- `npm test` *(fails: Missing script)*