### PR TITLE
Stop bubbling click events in FieldPicker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Agent Instructions
+
+This repository contains a ServiceNow UI Builder component for designing Adaptive Cards.
+The project requires Node.js version 14 or newer.
+
+## Coding Guidelines
+- Source code lives primarily in `src/`. Use TypeScript when possible.
+- Follow the lint rules defined in `.eslintrc.js`. Naming conventions prefer camelCase for variables and PascalCase for types and classes.
+- Prettier formatting is enforced via ESLint, so run a formatter before committing.
+
+## Recommended Checks
+- There are currently no automated tests or build scripts. If you add any, document them and ensure they pass (`npm test` etc.).
+- When making changes, attempt to run `npx eslint .` to catch style issues.
+
+## Commit Messages
+- Use clear, descriptive commit messages summarizing your changes.
+
+## Documentation
+- Update `README.md` when you add new features or usage examples.
+

--- a/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
@@ -85,7 +85,9 @@ export const addFieldPickersToDesigner = (designer, tableFields) => {
                 // Log whether this field is a reference field
                 console.log(`Field ${field.name} isReference:`, field.isReference, "Type:", field.type);
                 
-                item.onclick = () => {
+                item.onclick = (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
                     const reference = field.isReference
                         ? `\${current.${field.name}.display_value}`
                         : `\${current.${field.name}}`;
@@ -114,7 +116,9 @@ export const addFieldPickersToDesigner = (designer, tableFields) => {
             });
         }
 
-        overlay.onclick = () => {
+        overlay.onclick = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
             overlay.remove();
             modal.remove();
         };


### PR DESCRIPTION
## Summary
- prevent click events in `FieldPicker` from bubbling so ServiceNow's runtime doesn't crash when `sandboxEffect` tries to read a missing event

## Testing
- `npx eslint .` *(fails: couldn't find eslint.config.js)*