### PR TITLE
Fix reference field picker flow

### DIFF
--- a/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
@@ -98,21 +98,24 @@ export const addFieldPickersToDesigner = (designer, tableFields, dispatch) => {
                     arrow.onclick = (ev) => {
                         ev.preventDefault();
                         ev.stopPropagation();
-                        const eventDetail = {
-                            type: "reference-table-requested",
-                            payload: { tableName: field.referenceTable }
-                        };
+
                         const event = new CustomEvent("reference-table-requested", {
                             bubbles: true,
                             composed: true,
-                            detail: eventDetail
-                        });
-                        designer.hostElement.dispatchEvent(event);
-                        if (typeof dispatch === "function") {
-                            dispatch({
+                            detail: {
                                 type: "reference-table-requested",
                                 payload: { tableName: field.referenceTable }
-                            });
+                            }
+                        });
+                        designer.hostElement.dispatchEvent(event);
+
+                        if (typeof dispatch === "function") {
+                            // UI Core dispatch expects the action name as the
+                            // first argument followed by the payload
+                            dispatch(
+                                "reference-table-requested",
+                                { tableName: field.referenceTable }
+                            );
                         }
                     };
                     item.appendChild(arrow);

--- a/src/x-apig-adaptive-cards-designer-servicenow/index.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/index.js
@@ -180,6 +180,9 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
 
                                 if (state.designer) {
                                         addFieldPickersToDesigner(state.designer, parsedFields, dispatch);
+        if (state.designer._showFieldPicker && state.designer._lastFieldPickerInput) {
+            state.designer._showFieldPicker(state.designer._lastFieldPickerInput);
+        }
                                 } else {
                                         console.warn("Designer not initialized yet, field pickers will be added when it's ready");
                                 }


### PR DESCRIPTION
## Summary
- reopen the field picker modal when new reference fields are loaded

## Testing
- `npx eslint .` *(fails: couldn't find eslint.config.js)*