### PR TITLE
Fix event name mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ detail: {
 ```
 
 Listen for this event in UI Builder and provide the resulting fields back to the
-component via the `referenceFields` property to update the modal with the dot
-walked table's fields. Both the property and the `reference-table-requested`
-event are declared in `now-ui.json` so they appear in the UI Builder
-configuration panel.
+component via the `referenceFields` property. When both the `referenceTable`
+and `referenceFields` properties are populated, the component caches the table's
+fields locally and refreshes the modal with the new options. Subsequent requests
+for the same table reuse the cached values. Both the properties and the
+`reference-table-requested` event are declared in `now-ui.json` so they appear in
+the UI Builder configuration panel.

--- a/now-ui.json
+++ b/now-ui.json
@@ -60,13 +60,13 @@
         {
           "name": "reference-table-requested",
           "label": "Reference Table Requested",
-          "description": "Request to load fields for a referenced table",
+          "description": "Dispatched when the user requests fields for a referenced table",
           "action": "reference-table-requested",
           "payload": [
             {
               "name": "tableName",
               "label": "Table Name",
-              "description": "Name of the referenced table to fetch fields from",
+              "description": "Name of the referenced table",
               "type": "string"
             }
           ]
@@ -74,7 +74,7 @@
       ],
       "events": [
         {
-          "name": "REFERENCE_TABLE_REQUESTED",
+          "name": "reference-table-requested",
           "label": "Reference Table Requested",
           "description": "Emitted when a reference field arrow is clicked",
           "action": "reference-table-requested",
@@ -83,98 +83,6 @@
               "name": "tableName",
               "label": "Table Name",
               "description": "The referenced table to fetch fields for",
-              "type": "string"
-            }
-          ]
-        }
-      ],
-      "actions": [
-        {
-          "name": "reference-table-requested",
-          "label": "Reference Table Requested",
-          "description": "Dispatched when the user clicks a reference field's arrow to dot walk",
-          "action": "reference-table-requested",
-          "payload": [
-            {
-              "name": "tableName",
-              "label": "Table Name",
-              "description": "Name of the referenced table",
-              "type": "string"
-            }
-          ]
-        }
-      ],
-      "actions": [
-        {
-          "name": "reference-table-requested",
-          "label": "Reference Table Requested",
-          "description": "Fired when the arrow next to a reference field is clicked",
-          "action": "reference-table-requested",
-          "payload": [
-            {
-              "name": "tableName",
-              "label": "Table Name",
-              "description": "Name of the referenced table",
-              "type": "string"
-            }
-          ]
-        }
-      ],
-      "actions": [
-        {
-          "name": "reference-table-requested",
-          "label": "Reference Table Requested",
-          "description": "Emitted when a reference field arrow is clicked",
-          "action": "reference-table-requested",
-          "payload": [
-            {
-              "name": "tableName",
-              "label": "Table Name",
-              "type": "string"
-            }
-          ]
-        }
-      ],
-      "actions": [
-        {
-          "name": "reference-table-requested",
-          "label": "Reference Table Requested",
-          "description": "Fired when navigating to a referenced table",
-          "action": "reference-table-requested",
-          "payload": [
-            {
-              "name": "tableName",
-              "label": "Table Name",
-              "type": "string"
-            }
-          ]
-        }
-      ],
-      "actions": [
-        {
-          "name": "reference-table-requested",
-          "label": "Reference Table Requested",
-          "description": "Dispatched when a reference field arrow is clicked",
-          "action": "reference-table-requested",
-          "payload": [
-            {
-              "name": "tableName",
-              "label": "Table Name",
-              "type": "string"
-            }
-          ]
-        }
-      ],
-      "actions": [
-        {
-          "name": "reference-table-requested",
-          "description": "Dispatched when requesting fields from a referenced table",
-          "action": "reference-table-requested",
-          "payload": [
-            {
-              "name": "tableName",
-              "label": "Table Name",
-              "description": "Name of the referenced table",
               "type": "string"
             }
           ]

--- a/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
@@ -40,6 +40,16 @@ export const addFieldPickersToDesigner = (designer, tableFields, dispatch) => {
     const showFieldPicker = (input) => {
         designer._showFieldPicker = showFieldPicker;
         designer._lastFieldPickerInput = input;
+
+        if (designer._fieldPickerOverlay) {
+            designer._fieldPickerOverlay.remove();
+            designer._fieldPickerOverlay = null;
+        }
+        if (designer._fieldPickerModal) {
+            designer._fieldPickerModal.remove();
+            designer._fieldPickerModal = null;
+        }
+
         console.log("Showing field picker for input:", input);
 
         const fieldsForModal = designer._availableFieldPickerFields || [];

--- a/src/x-apig-adaptive-cards-designer-servicenow/index.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/index.js
@@ -61,6 +61,7 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                 properties: {},
                 referenceTable: "",
                 referenceFields: [],
+                referenceCache: {},
         },
 	actionHandlers: {
 		[actionTypes.COMPONENT_CONNECTED]: async ({
@@ -176,17 +177,29 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                                                    (typeof value === 'object' && value !== null) ? [value] : [];
 
                                 const parsedFields = processTableFields(fieldsArray);
-                                updateState({ referenceFields: parsedFields });
+
+                                const newCache = { ...state.referenceCache };
+                                if (state.referenceTable) {
+                                        newCache[state.referenceTable] = parsedFields;
+                                }
+
+                                updateState({ referenceFields: parsedFields, referenceCache: newCache });
 
                                 if (state.designer) {
                                         addFieldPickersToDesigner(state.designer, parsedFields, dispatch);
-        if (state.designer._showFieldPicker && state.designer._lastFieldPickerInput) {
-            state.designer._showFieldPicker(state.designer._lastFieldPickerInput);
-        }
+                                        if (state.designer._showFieldPicker && state.designer._lastFieldPickerInput) {
+                                                state.designer._showFieldPicker(state.designer._lastFieldPickerInput);
+                                        }
                                 } else {
                                         console.warn("Designer not initialized yet, field pickers will be added when it's ready");
                                 }
                         } else if (name === "referenceTable") {
+                                if (state.referenceCache[value] && state.designer) {
+                                        addFieldPickersToDesigner(state.designer, state.referenceCache[value], dispatch);
+                                        if (state.designer._showFieldPicker && state.designer._lastFieldPickerInput) {
+                                                state.designer._showFieldPicker(state.designer._lastFieldPickerInput);
+                                        }
+                                }
                                 updateState({ referenceTable: value });
                         } else if (
                                 name === "predefinedCard" &&


### PR DESCRIPTION
## Summary
- clean up manifest and normalize event name
- cache dot-walked fields and reload modal when the data arrives
- close old modals before showing updated field lists
- document the caching behavior

## Testing
- `npx eslint .` *(fails: ESLint couldn't find an eslint.config.js file)*