### PR TITLE
Align event names for card updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Design adaptive cards with a UI Builder component.
 ### Reference field navigation
 
 Reference type fields displayed in the picker now include an arrow button. When
-clicked the component dispatches a `reference-table-requested` event bubbling
+clicked the component dispatches a `REFERENCE_TABLE_FIELDS_REQUESTED` event bubbling
 from the component's root. The event detail follows the `type`/`payload`
 format expected by UI Builder and includes the referenced table name:
 
 ```javascript
 detail: {
-  type: 'reference-table-requested',
+  type: 'REFERENCE_TABLE_FIELDS_REQUESTED',
   payload: { tableName: 'sys_user' }
 }
 ```
@@ -21,14 +21,14 @@ component via the `referenceFields` property. When both the `referenceTable`
 and `referenceFields` properties are populated, the component caches the table's
 fields locally and refreshes the modal with the new options. Subsequent requests
 for the same table reuse the cached values. Both the properties and the
-`reference-table-requested` event are declared in `now-ui.json` so they appear in
+`REFERENCE_TABLE_FIELDS_REQUESTED` event are declared in `now-ui.json` so they appear in
 the UI Builder configuration panel.
 
 ### Registering the event in the instance
 
 UI Builder only exposes events that are registered on the instance. After
 deploying the component, create a `sys_ux_event` record with the name
-`reference-table-requested` and add it to the dispatched events list on the
+`REFERENCE_TABLE_FIELDS_REQUESTED` and add it to the dispatched events list on the
 component's macroponent record. Once registered you can map the event to any
 handler action on your page.
 

--- a/now-ui.json
+++ b/now-ui.json
@@ -72,10 +72,10 @@
           ]
         },
         {
-          "name": "card-state-changed",
+          "name": "CARD_STATE_CHANGED",
           "label": "Card State Changed",
           "description": "Emitted when the card JSON is modified",
-          "action": "card-state-changed",
+          "action": "CARD_STATE_CHANGED",
           "payload": [
             {
               "name": "card",

--- a/src/x-apig-adaptive-cards-designer-servicenow/index.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/index.js
@@ -33,11 +33,11 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                                 additionalProperties: false
                         }
                 },
-                "card-state-changed": {
-                        schema: {
-                                type: "object",
-                                properties: {
-                                        card: { type: "object" }
+               "CARD_STATE_CHANGED": {
+                       schema: {
+                               type: "object",
+                               properties: {
+                                       card: { type: "object" }
                                 },
                                 additionalProperties: false
                         }


### PR DESCRIPTION
## Summary
- standardize CARD_STATE_CHANGED event naming
- update event definitions in `now-ui.json`
- clarify README with new REFERENCE_TABLE_FIELDS_REQUESTED event name

## Testing
- `npx eslint .`
- `node -e "require('./now-ui.json'); console.log('ok')"`