### PR TITLE
Add card string to change event

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Design adaptive cards with a UI Builder component.
 ### Reference field navigation
 
 Reference type fields displayed in the picker now include an arrow button. When
-clicked the component dispatches a `reference-table-requested` event bubbling
+clicked the component dispatches a `REFERENCE_TABLE_FIELDS_REQUESTED` event bubbling
 from the component's root. The event detail follows the `type`/`payload`
 format expected by UI Builder and includes the referenced table name:
 
 ```javascript
 detail: {
-  type: 'reference-table-requested',
+  type: 'REFERENCE_TABLE_FIELDS_REQUESTED',
   payload: { tableName: 'sys_user' }
 }
 ```
@@ -21,14 +21,14 @@ component via the `referenceFields` property. When both the `referenceTable`
 and `referenceFields` properties are populated, the component caches the table's
 fields locally and refreshes the modal with the new options. Subsequent requests
 for the same table reuse the cached values. Both the properties and the
-`reference-table-requested` event are declared in `now-ui.json` so they appear in
+`REFERENCE_TABLE_FIELDS_REQUESTED` event are declared in `now-ui.json` so they appear in
 the UI Builder configuration panel.
 
 ### Registering the event in the instance
 
 UI Builder only exposes events that are registered on the instance. After
 deploying the component, create a `sys_ux_event` record with the name
-`reference-table-requested` and add it to the dispatched events list on the
+`REFERENCE_TABLE_FIELDS_REQUESTED` and add it to the dispatched events list on the
 component's macroponent record. Once registered you can map the event to any
 handler action on your page.
 
@@ -36,7 +36,9 @@ handler action on your page.
 
 The designer emits a `CARD_STATE_CHANGED` event whenever the card JSON is
 modified. Listen for this event and persist the `card` payload using the
-ServiceNow table API or your own storage mechanism.
+ServiceNow table API or your own storage mechanism. The event also includes
+a `cardString` field with the stringified JSON, which is handy for binding to
+labels or other text values in UI Builder.
 
 To load a previously saved card into the designer, dispatch the `LOAD_CARD`
 action with the card JSON:

--- a/now-ui.json
+++ b/now-ui.json
@@ -72,16 +72,22 @@
           ]
         },
         {
-          "name": "card-state-changed",
+          "name": "CARD_STATE_CHANGED",
           "label": "Card State Changed",
           "description": "Emitted when the card JSON is modified",
-          "action": "card-state-changed",
+          "action": "CARD_STATE_CHANGED",
           "payload": [
             {
               "name": "card",
               "label": "Card",
               "description": "Updated card JSON",
               "type": "object"
+            },
+            {
+              "name": "cardString",
+              "label": "Card String",
+              "description": "Stringified card JSON",
+              "type": "string"
             }
           ]
         }
@@ -97,6 +103,26 @@
               "name": "tableName",
               "label": "Table Name",
               "description": "The referenced table to fetch fields for",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "CARD_STATE_CHANGED",
+          "label": "Card State Changed",
+          "description": "Emitted when the card JSON is modified",
+          "action": "CARD_STATE_CHANGED",
+          "payload": [
+            {
+              "name": "card",
+              "label": "Card",
+              "description": "Updated card JSON",
+              "type": "object"
+            },
+            {
+              "name": "cardString",
+              "label": "Card String",
+              "description": "Stringified card JSON",
               "type": "string"
             }
           ]

--- a/src/x-apig-adaptive-cards-designer-servicenow/components/DesignerInitializer.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/components/DesignerInitializer.js
@@ -199,12 +199,18 @@ export const initializeDesigner = async (properties, updateState, host, dispatch
                                                 }));
 
                                                if (typeof dispatch === "function") {
-                                                       dispatch("CARD_STATE_CHANGED", { card: cardPayload });
+                                                       dispatch("CARD_STATE_CHANGED", {
+                                                               card: cardPayload,
+                                                               cardString: JSON.stringify(cardPayload)
+                                                       });
                                                }
                                                const changeEvent = new CustomEvent("sn:CARD_STATE_CHANGED", {
                                                        bubbles: true,
                                                        composed: true,
-                                                       detail: { card: cardPayload }
+                                                       detail: {
+                                                               card: cardPayload,
+                                                               cardString: JSON.stringify(cardPayload)
+                                                       }
                                                });
                                                host.dispatchEvent(changeEvent);
 

--- a/src/x-apig-adaptive-cards-designer-servicenow/index.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/index.js
@@ -33,15 +33,16 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                                 additionalProperties: false
                         }
                 },
-                "card-state-changed": {
-                        schema: {
-                                type: "object",
-                                properties: {
-                                        card: { type: "object" }
+               "CARD_STATE_CHANGED": {
+                       schema: {
+                               type: "object",
+                               properties: {
+                                       card: { type: "object" },
+                                       cardString: { type: "string" }
                                 },
                                 additionalProperties: false
                         }
-                },
+               },
                 "LOAD_CARD": {
                         schema: {
                                 type: "object",


### PR DESCRIPTION
## Summary
- dispatch `cardString` alongside the card object
- describe the new field in the README
- expose `CARD_STATE_CHANGED` event in UI Builder configuration

## Testing
- `npx eslint .`
- `node -e "require('./now-ui.json'); console.log('ok')"`
