### PR TITLE
Fix card state event details

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Design adaptive cards with a UI Builder component.
 ### Reference field navigation
 
 Reference type fields displayed in the picker now include an arrow button. When
-clicked the component dispatches a `reference-table-requested` event bubbling
+clicked the component dispatches a `REFERENCE_TABLE_FIELDS_REQUESTED` event bubbling
 from the component's root. The event detail follows the `type`/`payload`
 format expected by UI Builder and includes the referenced table name:
 
 ```javascript
 detail: {
-  type: 'reference-table-requested',
+  type: 'REFERENCE_TABLE_FIELDS_REQUESTED',
   payload: { tableName: 'sys_user' }
 }
 ```
@@ -21,22 +21,24 @@ component via the `referenceFields` property. When both the `referenceTable`
 and `referenceFields` properties are populated, the component caches the table's
 fields locally and refreshes the modal with the new options. Subsequent requests
 for the same table reuse the cached values. Both the properties and the
-`reference-table-requested` event are declared in `now-ui.json` so they appear in
+`REFERENCE_TABLE_FIELDS_REQUESTED` event are declared in `now-ui.json` so they appear in
 the UI Builder configuration panel.
 
 ### Registering the event in the instance
 
 UI Builder only exposes events that are registered on the instance. After
 deploying the component, create a `sys_ux_event` record with the name
-`reference-table-requested` and add it to the dispatched events list on the
+`REFERENCE_TABLE_FIELDS_REQUESTED` and add it to the dispatched events list on the
 component's macroponent record. Once registered you can map the event to any
 handler action on your page.
 
 ### Saving and loading cards
 
 The designer emits a `CARD_STATE_CHANGED` event whenever the card JSON is
-modified. Listen for this event and persist the `card` payload using the
-ServiceNow table API or your own storage mechanism.
+modified. The event detail provides both the `card` object and a `cardString`
+value so you can easily bind the JSON text in UI Builder. Listen for this event
+and persist the `card` payload using the ServiceNow table API or your own
+storage mechanism.
 
 To load a previously saved card into the designer, dispatch the `LOAD_CARD`
 action with the card JSON:

--- a/now-ui.json
+++ b/now-ui.json
@@ -72,16 +72,22 @@
           ]
         },
         {
-          "name": "card-state-changed",
+          "name": "CARD_STATE_CHANGED",
           "label": "Card State Changed",
           "description": "Emitted when the card JSON is modified",
-          "action": "card-state-changed",
+          "action": "CARD_STATE_CHANGED",
           "payload": [
             {
               "name": "card",
               "label": "Card",
               "description": "Updated card JSON",
               "type": "object"
+            },
+            {
+              "name": "cardString",
+              "label": "Card String",
+              "description": "String form of the updated card JSON",
+              "type": "string"
             }
           ]
         }

--- a/src/x-apig-adaptive-cards-designer-servicenow/components/DesignerInitializer.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/components/DesignerInitializer.js
@@ -198,13 +198,15 @@ export const initializeDesigner = async (properties, updateState, host, dispatch
                                                         designer: designer,
                                                 }));
 
+                                               const cardString = JSON.stringify(cardPayload);
+
                                                if (typeof dispatch === "function") {
-                                                       dispatch("CARD_STATE_CHANGED", { card: cardPayload });
+                                                       dispatch("CARD_STATE_CHANGED", { card: cardPayload, cardString });
                                                }
                                                const changeEvent = new CustomEvent("sn:CARD_STATE_CHANGED", {
                                                        bubbles: true,
                                                        composed: true,
-                                                       detail: { card: cardPayload }
+                                                       detail: { card: cardPayload, cardString }
                                                });
                                                host.dispatchEvent(changeEvent);
 

--- a/src/x-apig-adaptive-cards-designer-servicenow/index.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/index.js
@@ -33,11 +33,12 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                                 additionalProperties: false
                         }
                 },
-                "card-state-changed": {
-                        schema: {
-                                type: "object",
-                                properties: {
-                                        card: { type: "object" }
+               "CARD_STATE_CHANGED": {
+                       schema: {
+                               type: "object",
+                               properties: {
+                                       card: { type: "object" },
+                                       cardString: { type: "string" }
                                 },
                                 additionalProperties: false
                         }
@@ -446,12 +447,16 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
 							`Setting card (attempt ${i + 1}/${maxRetries}):`,
 							cardData
 						);
-						state.designer.setCard(cardData);
+                                                state.designer.setCard(cardData);
 
-						// Wait a bit for the UI to update
-						await new Promise((resolve) => setTimeout(resolve, 50));
+                                                // Wait a bit for the UI to update
+                                                await new Promise((resolve) => setTimeout(resolve, 50));
 
-						updateState({ currentCardState: cardData });
+                                                if (state.designer.updateJsonFromCard) {
+                                                    state.designer.updateJsonFromCard();
+                                                }
+
+                                                updateState({ currentCardState: cardData });
 
 						lastError = null;
 						break;
@@ -649,6 +654,11 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                         if (cardData && state.designer) {
                                 const processed = processCardData(cardData);
                                 state.designer.setCard(processed);
+
+                                if (state.designer.updateJsonFromCard) {
+                                    state.designer.updateJsonFromCard();
+                                }
+
                                 updateState({ currentCardState: processed });
                         }
                 },


### PR DESCRIPTION
## Summary
- include `cardString` field in `CARD_STATE_CHANGED` events
- trigger event when properties or load action set a new card
- document `cardString` usage in README

## Testing
- `npx eslint .`
- `node -e "require('./now-ui.json'); console.log('ok')"`
