### PR TITLE
Hide designer toolbar and toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,19 @@ detail: {
 }
 ```
 
-To load a previously saved card into the designer, dispatch the `LOAD_CARD`
-action with the card JSON:
+To load a previously saved card into the designer, assign the card JSON to the
+`predefinedCard` property:
 
 ```javascript
-component.dispatch('LOAD_CARD', { card: savedCard });
+component.predefinedCard = savedCard;
 ```
 
 Utility helpers `saveCard` and `loadCard` are available in
 `src/x-apig-adaptive-cards-designer-servicenow/util/cardStorage.js` and show how
 to interact with the table API.
+
+The component hides the designer's default toolbar and bottom toolbox (including
+the JSON editor) to provide a streamlined editing surface.
 
 Run `npx eslint .` to check for style issues. The project uses the flat config
 in `eslint.config.js`.

--- a/src/x-apig-adaptive-cards-designer-servicenow/index.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/index.js
@@ -5,7 +5,6 @@ import { view } from './components/DesignerView.js';
 import { initializeDesigner } from './components/DesignerInitializer.js';
 import { addFieldPickersToDesigner } from './components/FieldPicker.js';
 import { processTableFields, processCardData } from './util/servicenow-data-processor.js';
-import { loadCard } from './util/cardStorage.js';
 import { areJsonEqual } from './util/state-utils.js';
 
 // Main component definition
@@ -43,18 +42,8 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                                 },
                                 additionalProperties: false
                         }
-               },
-                "LOAD_CARD": {
-                        schema: {
-                                type: "object",
-                                properties: {
-                                        card: { type: "object" },
-                                        sysId: { type: "string" }
-                                },
-                                additionalProperties: false
-                        }
-                }
-        },
+               }
+       },
         properties: {
 		predefinedCard: {
 			schema: { type: "object" },
@@ -635,35 +624,6 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
                                     };
                                 }
                             }
-                        }
-                },
-                "LOAD_CARD": async ({ action, state, updateState }) => {
-                        let cardData = null;
-                        if (action) {
-                                if (typeof action.card === "object") {
-                                        cardData = action.card;
-                                } else if (action.payload && typeof action.payload.card === "object") {
-                                        cardData = action.payload.card;
-                                }
-
-                                if (!cardData && action.sysId) {
-                                        try {
-                                                cardData = await loadCard(action.sysId);
-                                        } catch (error) {
-                                                console.error("Error loading card:", error);
-                                        }
-                                }
-                        }
-
-                        if (cardData && state.designer) {
-                                const processed = processCardData(cardData);
-                                state.designer.setCard(processed);
-
-                                if (state.designer.updateJsonFromCard) {
-                                    state.designer.updateJsonFromCard();
-                                }
-
-                                updateState({ currentCardState: processed });
                         }
                 },
                 [actionTypes.COMPONENT_DISCONNECTED]: ({ host }) => {

--- a/src/x-apig-adaptive-cards-designer-servicenow/styles/designerStyles.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/styles/designerStyles.js
@@ -141,4 +141,15 @@ export const monacoStyles = `
     .acd-toolbox {
         overflow: hidden !important;
     }
+
+    /* Hide the main toolbar and bottom panels */
+    .designer-toolbar {
+        display: none !important;
+    }
+    .acd-toolbox {
+        display: none !important;
+    }
+    .acd-json-editor-pane {
+        display: none !important;
+    }
 `;


### PR DESCRIPTION
## Summary
- hide the built-in toolbar and toolbox sections so only the card canvas shows
- document the simplified interface in the README

## Testing
- `npx eslint .`