### PR TITLE
Fix icon fonts for designer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,11 @@ to interact with the table API.
 The component hides the designer's default toolbar and bottom toolbox (including
 the JSON editor) to provide a streamlined editing surface.
 
+### Icon fonts
+
+The designer relies on the Fluent and Codicon icon fonts. These fonts are bundled
+with the component and loaded when the designer initializes so the toolbar and
+Monaco editor icons display correctly.
+
 Run `npx eslint .` to check for style issues. The project uses the flat config
 in `eslint.config.js`.

--- a/src/x-apig-adaptive-cards-designer-servicenow/components/DesignerInitializer.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/components/DesignerInitializer.js
@@ -3,6 +3,7 @@ import * as ACDesigner from "adaptivecards-designer";
 import { ServiceNowCardDesigner } from '../components/ServiceNowCardDesigner.js';
 import { createGlobalDocumentProxy } from '../util/DocumentProxy.js';
 import { designerStyles, monacoStyles } from '../styles/designerStyles.js';
+import { codiconStyles, codiconModifierStyles } from '../styles/codiconStyles.js';
 import { areJsonEqual, debounce } from '../util/state-utils.js';
 
 export const initializeDesigner = async (properties, updateState, host, dispatch, state) => {
@@ -14,9 +15,13 @@ export const initializeDesigner = async (properties, updateState, host, dispatch
 		shadowRoot.appendChild(mainStyles);
 
 		// Add custom Monaco styles
-		const monacoStylesElement = document.createElement("style");
-		monacoStylesElement.textContent = monacoStyles;
-		shadowRoot.appendChild(monacoStylesElement);
+                const monacoStylesElement = document.createElement("style");
+                monacoStylesElement.textContent = monacoStyles;
+                shadowRoot.appendChild(monacoStylesElement);
+
+                const codiconStylesElement = document.createElement("style");
+                codiconStylesElement.textContent = codiconStyles + codiconModifierStyles;
+                shadowRoot.appendChild(codiconStylesElement);
 
 		createGlobalDocumentProxy(shadowRoot);
 

--- a/src/x-apig-adaptive-cards-designer-servicenow/styles/codiconStyles.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/styles/codiconStyles.js
@@ -1,0 +1,54 @@
+import codiconTtf from "./codicon.ttf";
+
+export const codiconStyles = `
+@font-face {
+    font-family: "codicon";
+    font-display: block;
+    src: url("${codiconTtf}") format("truetype");
+}
+
+.codicon[class*='codicon-'] {
+    font: normal normal normal 16px/1 codicon;
+    display: inline-block;
+    text-decoration: none;
+    text-rendering: auto;
+    text-align: center;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+}
+/* icon rules are dynamically created in codiconStyles */
+`;
+
+export const codiconModifierStyles = `
+.codicon-wrench-subaction {
+    opacity: 0.5;
+}
+
+@keyframes codicon-spin {
+    100% {
+        transform:rotate(360deg);
+    }
+}
+
+.codicon-sync.codicon-modifier-spin,
+.codicon-loading.codicon-modifier-spin,
+.codicon-gear.codicon-modifier-spin,
+.codicon-notebook-state-executing.codicon-modifier-spin {
+    /* Use steps to throttle FPS to reduce CPU usage */
+    animation: codicon-spin 1.5s steps(30) infinite;
+}
+
+.codicon-modifier-disabled {
+    opacity: 0.4;
+}
+
+/* custom speed & easing for loading icon */
+.codicon-loading,
+.codicon-tree-item-loading::before {
+    animation-duration: 1s !important;
+    animation-timing-function: cubic-bezier(0.53, 0.21, 0.29, 0.67) !important;
+}
+`;

--- a/src/x-apig-adaptive-cards-designer-servicenow/styles/designerStyles.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/styles/designerStyles.js
@@ -1,7 +1,9 @@
+import fabricIcons from "../fabricmdl2icons-3.54.woff";
+
 export const designerStyles = `
     @font-face {
         font-family: "FabricMDL2Icons";
-        src: url("https://static2.sharepointonline.com/files/fabric/assets/icons/fabricmdl2icons-3.54.woff") format("woff");
+        src: url("${fabricIcons}") format("woff");
     }
     :host {
         display: block;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,11 @@ module.exports = {
         test: /\.ttf$/,
         use: ['file-loader']
       }
+      ,
+      {
+        test: /\.woff2?$/,
+        use: ['file-loader']
+      }
     ]
   },
   externals: {


### PR DESCRIPTION
## Summary
- reference local Fabric icons font instead of remote URL
- add codicon font styles and load them in the designer
- bundle `.woff` fonts in webpack
- document icon fonts in README

## Testing
- `npx eslint .`
