### PR TITLE
Update to latest Adaptive Cards CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,15 @@ Monaco editor icons display correctly.
 
 Run `npx eslint .` to check for style issues. The project uses the flat config
 in `eslint.config.js`.
+
+### Loading the designer from the CDN
+
+Include the Adaptive Cards Designer bundle before using the component:
+
+```html
+<script src="https://adaptivecards.microsoft.com/main.bundle.js"></script>
+```
+
+The component automatically sets the `assetPath` to
+`https://adaptivecards.microsoft.com` so all designer resources load from the
+same CDN.

--- a/onload.js
+++ b/onload.js
@@ -4,7 +4,7 @@ window.onload = function () {
     }
 
     let designer = new ACDesigner.CardDesigner(ACDesigner.defaultMicrosoftHosts);
-    designer.assetPath = "https://unpkg.com/adaptivecards-designer@latest/dist";
+    designer.assetPath = "https://adaptivecards.microsoft.com";
 
     designer.attachTo(document.getElementById("designerRootHost"));
     // initialize monaco editor and tell the Designer when it's been loaded

--- a/src/x-apig-adaptive-cards-designer-servicenow/components/DesignerInitializer.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/components/DesignerInitializer.js
@@ -163,8 +163,8 @@ export const initializeDesigner = async (properties, updateState, host, dispatch
 		ACDesigner.GlobalSettings.showTargetVersionMismatchWarning = false;
 
 		// Create and initialize the designer
-		const designer = new ServiceNowCardDesigner(hostContainers);
-		designer.assetPath = "https://unpkg.com/adaptivecards-designer@2.4.4/dist";
+                const designer = new ServiceNowCardDesigner(hostContainers);
+                designer.assetPath = "https://adaptivecards.microsoft.com";
 
 		// Initialize toolbox
 		designer.initializeToolbox(toolboxContent, toolboxHeader);


### PR DESCRIPTION
## Summary
- load designer assets from `https://adaptivecards.microsoft.com`
- document CDN usage in `README`

## Testing
- `npx eslint .`
