### PR TITLE
Preserve loaded fields

### DIFF
--- a/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/components/FieldPicker.js
@@ -55,18 +55,30 @@ export const addFieldPickersToDesigner = (designer, tableFields, dispatch) => {
     if (typeof dispatch === "function") {
         designer._fieldPickerDispatch = dispatch;
     } else {
-        console.warn("No dispatch function provided to addFieldPickersToDesigner, dot-walking may not work");
+        console.warn(
+            "No dispatch function provided to addFieldPickersToDesigner, dot-walking may not work"
+        );
         // Create a safe fallback dispatch function that logs errors
         designer._fieldPickerDispatch = (type, payload) => {
-            console.error("Cannot dispatch event, no dispatch function available", {type, payload});
+            console.error("Cannot dispatch event, no dispatch function available", { type, payload });
             return false;
         };
     }
+
+    // If we still have no fields available after initial checks, skip setup
+    if (!(designer._availableFieldPickerFields && designer._availableFieldPickerFields.length > 0)) {
+        console.warn(
+            "addFieldPickersToDesigner: no fields available, skipping picker setup"
+        );
+        return;
+    }
     
     // Log summary of available fields with more detailed information
-    console.log("Field picker available fields:", 
-        `Total: ${availableFields.length}, ` + 
-        `Reference fields: ${availableFields.filter(f => f.isReference).length}`);
+    console.log(
+        "Field picker available fields:",
+        `Total: ${availableFields.length}, ` +
+            `Reference fields: ${availableFields.filter((f) => f.isReference).length}`
+    );
     
     // Log field type distribution to help debug
     const fieldTypes = {};
@@ -692,16 +704,18 @@ export const addFieldPickersToDesigner = (designer, tableFields, dispatch) => {
                 
                 // Just before opening the picker, double check that we have fields
                 if (!designer._availableFieldPickerFields || designer._availableFieldPickerFields.length === 0) {
-                    console.warn("No fields available when opening field picker, checking for fields in closure");
-                    designer._availableFieldPickerFields = availableFields || [];
+                    console.warn(
+                        "No fields available when opening field picker, aborting"
+                    );
+                    return;
                 }
-                
+
                 // Log the state of fields just before opening the picker
                 console.log("Fields before opening picker:", {
                     fieldsFromDesigner: designer._availableFieldPickerFields?.length || 0,
-                    fieldsFromClosure: availableFields?.length || 0
+                    fieldsFromClosure: availableFields?.length || 0,
                 });
-                
+
                 showFieldPicker(input); // Use the showFieldPicker from the current scope
             };
             wrapper.appendChild(button);

--- a/src/x-apig-adaptive-cards-designer-servicenow/index.js
+++ b/src/x-apig-adaptive-cards-designer-servicenow/index.js
@@ -184,47 +184,46 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
 
 				// After designer is initialized, handle fields if provided
                                 if (properties.fields) {
-					console.log("COMPONENT_CONNECTED: Processing fields data");
-					
-					// Ensure we handle both array and non-array cases
-					const fieldsArray = Array.isArray(properties.fields) ? properties.fields : 
-					                   (typeof properties.fields === 'object' && properties.fields !== null) ? 
-					                   [properties.fields] : [];
-					                   
-					// Process the fields
-					const parsedFields = processTableFields(fieldsArray);
-					
-					console.log("COMPONENT_CONNECTED: Processed fields count:", parsedFields.length);
-					if (parsedFields.length > 0) {
-					    console.log("COMPONENT_CONNECTED: First processed field:", JSON.stringify(parsedFields[0], null, 2));
-					}
-					
-					// Update state with the processed fields
-					updateState({ tableFields: parsedFields });
+                                        console.log("COMPONENT_CONNECTED: Processing fields data");
 
-					// Add field pickers to the designer right away since we have the instance
-					if (designer) {
-                                                // Store fields directly on the designer as a property
-                                                designer._availableFieldPickerFields = parsedFields;
-                                                
-                                                // Double check we have some fields
-                                                console.log(`Adding ${parsedFields.length} fields to field picker`);
-                                                
-                                                // Then call addFieldPickersToDesigner which sets up the observers and handlers
-                                                addFieldPickersToDesigner(designer, parsedFields, dispatch);
-                                                
-                                                // Save the fields on the window for emergency recovery
-                                                window.__lastKnownTableFields = parsedFields;
-                                                
-                                                // Log the state of fields on the designer after setup
-                                                console.log("Fields stored on designer:", {
-                                                    count: designer._availableFieldPickerFields?.length || 0,
-                                                    sample: designer._availableFieldPickerFields?.length > 0 ? 
-                                                        JSON.stringify(designer._availableFieldPickerFields[0], null, 2) : "No fields"
-                                                });
-					} else {
-						console.warn("Designer not properly initialized, field pickers couldn't be added");
-					}
+                                        // Ensure we handle both array and non-array cases
+                                        const fieldsArray = Array.isArray(properties.fields) ? properties.fields :
+                                                           (typeof properties.fields === 'object' && properties.fields !== null) ?
+                                                           [properties.fields] : [];
+
+                                        // Process the fields
+                                        const parsedFields = processTableFields(fieldsArray);
+
+                                        console.log("COMPONENT_CONNECTED: Processed fields count:", parsedFields.length);
+                                        if (parsedFields.length > 0) {
+                                            console.log("COMPONENT_CONNECTED: First processed field:", JSON.stringify(parsedFields[0], null, 2));
+
+                                            // Update state with the processed fields
+                                            updateState({ tableFields: parsedFields });
+
+                                            if (designer) {
+                                                    // Store fields directly on the designer as a property
+                                                    designer._availableFieldPickerFields = parsedFields;
+
+                                                    console.log(`Adding ${parsedFields.length} fields to field picker`);
+
+                                                    // Then call addFieldPickersToDesigner which sets up the observers and handlers
+                                                    addFieldPickersToDesigner(designer, parsedFields, dispatch);
+
+                                                    // Save the fields on the window for emergency recovery
+                                                    window.__lastKnownTableFields = parsedFields;
+
+                                                    console.log("Fields stored on designer:", {
+                                                        count: designer._availableFieldPickerFields?.length || 0,
+                                                        sample: designer._availableFieldPickerFields?.length > 0 ?
+                                                            JSON.stringify(designer._availableFieldPickerFields[0], null, 2) : "No fields"
+                                                    });
+                                            } else {
+                                                    console.warn("Designer not properly initialized, field pickers couldn't be added");
+                                            }
+                                        } else {
+                                            console.log("COMPONENT_CONNECTED: Fields array empty, keeping existing data");
+                                        }
                                 } else {
                                         console.log("COMPONENT_CONNECTED: No fields provided in properties");
                                 }
@@ -274,30 +273,55 @@ createCustomElement("x-apig-adaptive-cards-designer-servicenow", {
             console.log("Property changed:", { name, value, valueType: typeof value });
 
                         if (name === "fields" && value) {
-				console.log("COMPONENT_PROPERTY_CHANGED: Received fields update. Raw value type:", typeof value, 
-				            "Is array?", Array.isArray(value),
-				            "Length:", Array.isArray(value) ? value.length : 'N/A',
-				            "Sample:", Array.isArray(value) && value.length > 0 ? JSON.stringify(value[0], null, 2) : 'No items');
-				
-				// Process the fields using our utility function - ensure we're passing an array
-				const fieldsArray = Array.isArray(value) ? value : 
-				                   (typeof value === 'object' && value !== null) ? [value] : [];
-				                   
-				const parsedFields = processTableFields(fieldsArray);
-				
-				console.log("COMPONENT_PROPERTY_CHANGED: Parsed fields count:", parsedFields.length);
-				if (parsedFields.length > 0) {
-				    console.log("COMPONENT_PROPERTY_CHANGED: First parsed field:", JSON.stringify(parsedFields[0], null, 2));
-				}
-				
-				// Update state with the new fields
-				updateState({ tableFields: parsedFields });
-				
-				// Add field pickers if designer is initialized
-                                if (state.designer) {
-                                        addFieldPickersToDesigner(state.designer, parsedFields, dispatch);
+                                console.log(
+                                    "COMPONENT_PROPERTY_CHANGED: Received fields update. Raw value type:",
+                                    typeof value,
+                                    "Is array?",
+                                    Array.isArray(value),
+                                    "Length:",
+                                    Array.isArray(value) ? value.length : 'N/A',
+                                    "Sample:",
+                                    Array.isArray(value) && value.length > 0 ? JSON.stringify(value[0], null, 2) : 'No items'
+                                );
+
+                                // Process the fields using our utility function - ensure we're passing an array
+                                const fieldsArray = Array.isArray(value)
+                                    ? value
+                                    : typeof value === 'object' && value !== null
+                                    ? [value]
+                                    : [];
+
+                                const parsedFields = processTableFields(fieldsArray);
+
+                                console.log(
+                                    "COMPONENT_PROPERTY_CHANGED: Parsed fields count:",
+                                    parsedFields.length
+                                );
+                                if (parsedFields.length > 0) {
+                                    console.log(
+                                        "COMPONENT_PROPERTY_CHANGED: First parsed field:",
+                                        JSON.stringify(parsedFields[0], null, 2)
+                                    );
+
+                                    // Update state with the new fields
+                                    updateState({ tableFields: parsedFields });
+
+                                    if (state.designer) {
+                                            addFieldPickersToDesigner(state.designer, parsedFields, dispatch);
+                                    } else {
+                                            console.warn(
+                                                "Designer not initialized yet, field pickers will be added when it's ready"
+                                            );
+                                    }
                                 } else {
-                                        console.warn("Designer not initialized yet, field pickers will be added when it's ready");
+                                    console.log(
+                                        "COMPONENT_PROPERTY_CHANGED: Empty fields update received, keeping existing data"
+                                    );
+
+                                    // Reapply existing fields to ensure pickers keep working
+                                    if (state.designer && state.tableFields && state.tableFields.length > 0) {
+                                            addFieldPickersToDesigner(state.designer, state.tableFields, dispatch);
+                                    }
                                 }
                         } else if (name === "referenceFields" && value) {
                                 const fieldsArray = Array.isArray(value) ? value :


### PR DESCRIPTION
## Summary
- avoid overwriting designer fields with empty data on init
- ignore empty field updates in property change handler

## Testing
- `npx eslint .`
